### PR TITLE
Fix parseModelDef for NatNet >=4.1.0

### DIFF
--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -113,6 +113,13 @@ namespace libmotioncapture {
           int type = 0; memcpy(&type, ptr, 4); ptr += 4;
           // printf("Type : %d\n", i, type);
 
+          if ((major == 4 && minor >= 1) || major > 4)
+          {
+            // If the NatNet version is 4.1 or greater, next four bytes represent
+            // the number of bytes in the dataset. Just skip them.
+            ptr += 4;
+          }
+
           if(type == 0)   // markerset
           {
             ptr += strlen(ptr) + 1; // name


### PR DESCRIPTION
In version 4.1.0 there seems to be an extra 4 bytes representing the length in bytes after the dataset type bytes. This was causing the lib to crash with a segmentation fault. In the Python client from optitrack the length doesn't seem to be used (yet?) so I just skip the bytes here.