### PR TITLE
CMake: fix use of boost system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(Threads REQUIRED)
-find_package(Boost 1.5 OPTIONAL_COMPONENTS system) # for optitrack
+find_package(Boost) # for optitrack
 add_definitions(
   -DBOOST_DATE_TIME_NO_LIB
   -DBOOST_REGEX_NO_LIB
@@ -91,10 +91,10 @@ if (LIBMOTIONCAPTURE_ENABLE_OPTITRACK)
     Boost::boost
     Threads::Threads
   )
-  if (Boost_SYSTEM_FOUND)
+  if (Boost_FOUND)
     set(my_libraries
       ${my_libraries}
-      Boost::system
+      Boost::boost
     )
   endif()
 endif()


### PR DESCRIPTION
fix:
```cmake
CMake Error at /nix/store/f1jzlprx190bfspq1i56bd0r8q9lwy0x-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/f1jzlprx190bfspq1i56bd0r8q9lwy0x-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:609 (find_package)
  deps/libmotioncapture/CMakeLists.txt:21 (find_package)

-- Configuring incomplete, errors occurred!
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89